### PR TITLE
Fix pull failures when username=None and password=None

### DIFF
--- a/conctl/containerd.py
+++ b/conctl/containerd.py
@@ -107,12 +107,8 @@ class ContainerdCtl(ContainerRuntimeCtlBase):
             urls = [urls]
 
         for url in urls:
-            return self._exec(
-                'image',
-                'pull',
-                '--user={}:{}'.format(
-                    username,
-                    password
-                ),
-                url
-            )
+            args = ['image', 'pull']
+            if username or password:
+                args.append('--user={}:{}'.format(username, password))
+            args.append(url)
+            return self._exec(*args)

--- a/conctl/docker.py
+++ b/conctl/docker.py
@@ -105,12 +105,13 @@ class DockerCtl(ContainerRuntimeCtlBase):
             urls = [urls]
 
         for url in urls:
-            self._exec(
-                'login',
-                url,
-                '-u', username,
-                '-p', password
-            )
+            if username or password:
+                self._exec(
+                    'login',
+                    url,
+                    '-u', username,
+                    '-p', password
+                )
 
             return self._exec(
                 'pull',


### PR DESCRIPTION
I ran this:

```
result = CTL.pull('docker.io/calico/node:v3.6.1')
log(result)
```

and saw this:
```
CompletedProcess(args=('ctr', 'image', 'pull', '--user=None:None', 'docker.io/calico/node:v3.6.1'), returncode=1, stdout=b'docker.io/calico/node:v3.6.1: resolving      |\x1b[32m\x1b[0m--------------------------------------| \nelapsed: 0.1 s                total:   0.0 B (0.0 B/s)                                         \n', stderr=b'ctr: failed to resolve reference "docker.io/calico/node:v3.6.1": failed to fetch oauth token: unexpected status: 401 Unauthorized\n')
```

It looks like it failed because of the `--user=None:None`. This should hopefully fix it. Needs testing.