### PR TITLE
Fix containerd delete

### DIFF
--- a/conctl/containerd.py
+++ b/conctl/containerd.py
@@ -89,11 +89,8 @@ class ContainerdCtl(ContainerRuntimeCtlBase):
         :param container_ids: List String
         :return: CompletedProcess
         """
-        for container_id in container_ids:
-            self._exec('task', 'kill', container_id)
-
         return self._exec(
-            'container', 'delete', *container_ids
+            'task', 'kill', '--all', *container_ids
         )
 
     def pull(self,


### PR DESCRIPTION
Change containerd delete routine to:
1) Run "task kill" with --all, so all processes are removed for given container
2) Run it once against a list of containers and return its output
3) Remove "container delete" since containers are removed after task successfully stopped all processes (that will result in an exception otherwise)

Closes: #6 