### PR TITLE
Remove snapshots when deleting containers

### DIFF
--- a/conctl/base.py
+++ b/conctl/base.py
@@ -1,8 +1,8 @@
 from typing import Dict, List, Optional
-from subprocess import (
+from subprocess import (  # noqa: F401
     run as sub_run,
     CompletedProcess,
-    CalledProcessError,  # noqa: F401
+    CalledProcessError,
     PIPE
 )
 

--- a/conctl/containerd.py
+++ b/conctl/containerd.py
@@ -116,6 +116,14 @@ class ContainerdCtl(ContainerRuntimeCtlBase):
             )
         except CalledProcessError:
             return killed
+        finally:
+            # lp:1932052 ensure snapshots are removed on delete
+            try:
+                self._exec(
+                    'snapshot', 'rm', *container_ids
+                )
+            except CalledProcessError:
+                pass
 
     def pull(self,
              urls: List[str],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='conctl',
-    version='0.1.2',
+    version='0.1.3',
     url='https://github.com/joedborg/conctl',
     license='Apache License 2.0',
     author='Joe Borg',

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -5,13 +5,13 @@ from conctl import getContainerRuntimeCtl
 
 class BasicTests(unittest.TestCase):
     def setUp(self):
-        self.ctl = getContainerRuntimeCtl()
+        self.ctl = getContainerRuntimeCtl('containerd')
 
     def tearDown(self):
         pass
 
-    def assert_valid_runtime(self):
-        self.assertIn(self.ctl.runtime, ['docker', 'containerd'])
+    def test_valid_runtime(self):
+        self.assertEqual(self.ctl.runtime, 'containerd')
 
 
 if __name__ == '__main__':

--- a/tests/test_containerd.py
+++ b/tests/test_containerd.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest import mock
+
+from subprocess import CalledProcessError
+from conctl.containerd import ContainerdCtl
+
+
+class ContainerdTests(unittest.TestCase):
+    def setUp(self):
+        self.ctl = ContainerdCtl()
+
+    def tearDown(self):
+        pass
+
+    def test_valid_runtime(self):
+        self.assertEqual(self.ctl.runtime, 'containerd')
+
+    @mock.patch("conctl.containerd.ContainerdCtl._exec")
+    def test_delete(self, mock_exec):
+        self.ctl.delete()
+
+        mock_exec.side_effect = CalledProcessError(1, cmd=['bad'])
+        calls = [
+            mock.call('task', 'kill', '--all'),
+            mock.call('container', 'delete'),
+            mock.call('snapshot', 'rm'),
+        ]
+        mock_exec.assert_has_calls(calls)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Per [LP:1932052](https://bugs.launchpad.net/charm-calico/+bug/1932052), we can get ourselves into a situation where a systemd service like `calico-node.service` starts but then stops before a necessary container is started. When the service comes up again, we may fail if the previous container hasn't been deleted and the associated snapshot removed / garbage collected.

This PR ensures we always at least *try* to remove a `container_id` snapshot when calling `delete()`.